### PR TITLE
cambiado nombre llamada a tarjetaSlider.css desde

### DIFF
--- a/src/components/TarjetaSlider.jsx
+++ b/src/components/TarjetaSlider.jsx
@@ -1,4 +1,4 @@
-import '../styles/TarjetaSlider.css';
+import '../styles/tarjetaSlider.css';
 
 
 const TarjetaSlider = (prop) => {


### PR DESCRIPTION
componente donde el import se referia erroneamente a
TarjetaSlider.css con Mayúscula